### PR TITLE
feat: hide any http capability behind feature in `pgp-lib`

### DIFF
--- a/mml/Cargo.toml
+++ b/mml/Cargo.toml
@@ -53,7 +53,7 @@ log = "0.4"
 mail-builder = "0.3"
 mail-parser = "0.9"
 nanohtml2text = { version = "0.1", optional = true }
-pgp-lib = { version = "=0.2.0", optional = true }
+pgp-lib = { version = "=0.2.0", optional = true, features = ["key-discovery"] }
 process-lib = { version = "=0.4.2", optional = true }
 secret-lib = { version = "=0.4.6", optional = true }
 serde = { version = "1", optional = true }

--- a/pgp/Cargo.toml
+++ b/pgp/Cargo.toml
@@ -13,7 +13,19 @@ keywords = ["pgp", "openpgp", "encrypt", "decrypt", "sign"]
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docs_rs"]
+
+[features]
+default = []
+key-discovery = [
+    "dep:async-recursion",
+    "dep:futures",
+    "dep:hyper",
+    "dep:hyper-rustls",
+    "dep:log",
+    "dep:sha1",
+    "dep:z-base-32",
+]
 
 [lib]
 name = "pgp"
@@ -25,16 +37,18 @@ tempfile = "3.3"
 tokio = { version = "1.23", default-features = false, features = ["macros", "rt"] }
 
 [dependencies]
-async-recursion = "1"
-futures = "0.3"
-hyper = { version = "0.14", default-features = false, features = [ "http1", "http2" ] }
-hyper-rustls = "0.24"
-log = "0.4"
 pgp_native = { version = "0.10", package = "pgp" }
 rand = "0.8"
-sha1 = "0.10"
 smallvec = "1"
 thiserror = "1"
 tokio = { version = "1.23", default-features = false, features = ["rt"] }
 url = "2.4"
-z-base-32 = "0.1"
+
+# Optional deps - 'http'
+async-recursion = { version = "1",  optional = true }
+futures = { version = "0.3", optional = true }
+hyper = { version = "0.14", default-features = false, features = [ "http1", "http2" ], optional = true }
+hyper-rustls = { version = "0.24", optional = true }
+log = { version = "0.4", optional = true }
+sha1 = { version = "0.10", optional = true }
+z-base-32 = { version = "0.1", optional = true }

--- a/pgp/src/error.rs
+++ b/pgp/src/error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "key-discovery")]
 use hyper::Uri;
 use pgp_native::{SecretKeyParamsBuilderError, SubkeyParamsBuilderError};
 use std::{
@@ -39,10 +40,13 @@ pub enum Error {
     ExportEncryptedMessageToArmorError(#[source] pgp_native::errors::Error),
     #[error("cannot compress pgp message")]
     CompressMessageError(#[source] pgp_native::errors::Error),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse body from {1}")]
     ParseBodyWithUriError(#[source] hyper::Error, Uri),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse response from {1}")]
     FetchResponseError(#[source] hyper::Error, Uri),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse pgp public key from {1}")]
     ParsePublicKeyError(#[source] pgp_native::errors::Error, Uri),
     #[error("cannot find pgp public key for email {0}")]
@@ -82,16 +86,20 @@ pub enum Error {
     VerifySignatureError(#[source] pgp_native::errors::Error),
     #[error("cannot parse email address {0}")]
     ParseEmailAddressError(String),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse url {1}")]
     ParseUrlError(#[source] url::ParseError, String),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse uri {1}")]
     ParseUriError(#[source] hyper::http::uri::InvalidUri, String),
     #[error("cannot parse path {1}")]
     ParseFilePathError(path::StripPrefixError, url::Url),
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse response")]
     ParseResponseError(#[source] hyper::Error),
     #[error("cannot parse response: too many redirect")]
     RedirectOverflowError,
+    #[cfg(feature = "key-discovery")]
     #[error("cannot parse body")]
     ParseBodyError(#[source] hyper::Error),
     #[error("cannot parse certificate")]

--- a/pgp/src/lib.rs
+++ b/pgp/src/lib.rs
@@ -1,14 +1,19 @@
+#![cfg_attr(docs_rs, feature(doc_cfg, doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
+#[cfg(feature = "key-discovery")]
 pub(crate) mod client;
 pub mod decrypt;
 pub mod encrypt;
 mod error;
+#[cfg(feature = "key-discovery")]
 pub mod hkp;
+#[cfg(feature = "key-discovery")]
 pub mod http;
 pub mod sign;
 pub mod utils;
 pub mod verify;
+#[cfg(feature = "key-discovery")]
 pub mod wkd;
 
 pub use pgp_native as native;


### PR DESCRIPTION
I'm currently using this crate to validate PGP keys, and it has breen great for it, and I saw it pulled older dependencies (`hyper 0.14` notably), so I put them behind a (default activated) feature to make it easier to use the crate without pulling unused deps

Despite the default activation, if someone was using `default-features = false` this will be a breaking change. I don't think anyone using this crate would have done this considering it had no features before

Also, I used `docs_rs` because using `docsrs` fails on recent nightly compilers (as used by docs.rs) because a dependency somewhere down the chain is not up to date with the latest format of `cfg`s for Rustdoc and it uses `docsrs` itself already.

With all that said, a screenshot to show how it will look:

<img width="640" alt="Modules section of `pgp`'s crate docs showing the hkp, http and wkd modules behind gated behind the http feature" src="https://github.com/user-attachments/assets/941f56d0-5c63-435b-84fe-2914184c3d5f">
