### PR TITLE
http: remove Arc from Client::agent

### DIFF
--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -3,8 +3,6 @@
 
 mod error;
 
-use std::sync::Arc;
-
 pub use ureq;
 use ureq::{
     config::Config,
@@ -35,8 +33,7 @@ compile_error!("Either feature `rustls` or `native-tls` must be enabled for this
 #[derive(Clone, Debug)]
 pub struct Client {
     /// The HTTP agent used to perform calls.
-    // TODO: agent pool?
-    agent: Arc<Agent>,
+    agent: Agent,
 }
 
 impl Client {
@@ -52,7 +49,7 @@ impl Client {
             );
 
         let config = Config::builder().tls_config(tls.build()).build();
-        let agent = Arc::new(config.new_agent());
+        let agent = config.new_agent();
 
         Self { agent }
     }


### PR DESCRIPTION
ureq::Agent contains fields which are arc and is safe to clone directly.
It serves no useful purpose to make this an Arc<Agent>

Discussion: https://matrix.to/#/!YoksPkuRbToNNITgZQ:matrix.org/$aLcrzNaTzMvTj_l--4NOWQVose7obcWNbPdLajgAshA?via=matrix.org&via=tchncs.de&via=arcticfoxes.net