### PR TITLE
fix(email): correct spelling in documentation comments

### DIFF
--- a/email/src/email/message/delete/mod.rs
+++ b/email/src/email/message/delete/mod.rs
@@ -17,7 +17,7 @@ use crate::{
     AnyResult,
 };
 
-/// eature to delete message(s).
+/// Feature to delete message(s).
 #[async_trait]
 pub trait DeleteMessages: Send + Sync {
     /// Delete messages from the given folder matching the given

--- a/email/src/email/message/get/mod.rs
+++ b/email/src/email/message/get/mod.rs
@@ -15,7 +15,7 @@ use crate::{
     AnyResult,
 };
 
-/// Get messages eature.
+/// Get messages feature.
 #[async_trait]
 pub trait GetMessages: Send + Sync {
     /// Get email messages from the given folder matching the given

--- a/email/src/email/message/remove/mod.rs
+++ b/email/src/email/message/remove/mod.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 
 use crate::{envelope::Id, AnyResult};
 
-/// eature to remove message(s).
+/// Feature to remove message(s).
 #[async_trait]
 pub trait RemoveMessages: Send + Sync {
     /// Remove messages from the given folder matching the given


### PR DESCRIPTION
I just added a 'f' letter before three typos
