### PR TITLE
feat(rip-starttls): Add smol runtime support which uses async-net

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,21 +416,20 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
 dependencies = [
- "async-lock",
+ "autocfg",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 1.1.2",
  "slab",
- "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -442,6 +441,17 @@ dependencies = [
  "event-listener 5.4.0",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -459,7 +469,7 @@ dependencies = [
  "cfg-if",
  "event-listener 5.4.0",
  "futures-lite",
- "rustix",
+ "rustix 0.38.43",
  "tracing",
 ]
 
@@ -486,7 +496,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.43",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -2513,9 +2523,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -3844,9 +3854,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libdbus-sys"
@@ -3952,6 +3962,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -5205,7 +5221,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.43",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -5824,9 +5840,12 @@ dependencies = [
 name = "rip-starttls"
 version = "0.1.0"
 dependencies = [
+ "async-net",
  "async-std",
  "env_logger",
+ "futures-lite",
  "rip-starttls",
+ "smol",
  "tokio",
  "tracing",
 ]
@@ -5951,8 +5970,21 @@ dependencies = [
  "bitflags 2.7.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.7.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6595,6 +6627,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
+name = "smol"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a33bd3e260892199c3ccfc487c88b2da2265080acb316cd920da72fdfd7c599f"
+dependencies = [
+ "async-channel 2.3.1",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-net",
+ "async-process",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
 name = "smtp"
 version = "0.9.0"
 source = "git+https://github.com/stalwartlabs/mail-server.git?tag=v0.9.0#644496db4597f1fb32380de4f37985428a01cb02"
@@ -6972,7 +7021,7 @@ dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix",
+ "rustix 0.38.43",
  "windows-sys 0.59.0",
 ]
 
@@ -7946,7 +7995,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.43",
 ]
 
 [[package]]
@@ -8050,6 +8099,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
 name = "windows-registry"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8113,6 +8168,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f109e41dd4a3c848907eb83d5a42ea98b3769495597450cf6d153507b166f0f"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/rip-starttls/Cargo.toml
+++ b/rip-starttls/Cargo.toml
@@ -19,9 +19,11 @@ rustdoc-args = ["--cfg", "docsrs"]
 std = []
 tokio = ["dep:tokio"]
 async-std = ["dep:async-std"]
+smol = ["dep:futures-lite", "dep:async-net"]
 
 [dev-dependencies]
 async-std = { version = "1.13", features = ["attributes"] }
+smol = { version = "2" }
 env_logger = "0.11"
 rip-starttls = { path = ".", features = ["std", "async-std", "tokio"] }
 tokio = { version = "1.37", features = ["full"] }
@@ -29,5 +31,10 @@ tracing = { version = "0.1", features = ["log"] }
 
 [dependencies]
 async-std = { version = "1.13", optional = true }
-tokio = { version = "1.37", optional = true, default-features = false, features = ["io-util", "net"] }
+tokio = { version = "1.37", optional = true, default-features = false, features = [
+    "io-util",
+    "net",
+] }
+futures-lite = { version = "2.0", optional = true }
+async-net = { version = "2.0", optional = true }
 tracing = "0.1"

--- a/rip-starttls/examples/imap-smol.rs
+++ b/rip-starttls/examples/imap-smol.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "smol")]
+
+use std::{env, net::Shutdown};
+
+use async_net::TcpStream;
+use rip_starttls::imap::smol::RipStarttls;
+
+fn main() {
+    smol::block_on(async_main());
+}
+
+async fn async_main() {
+    env_logger::builder().is_test(true).init();
+
+    let host = env::var("HOST").expect("HOST should be defined");
+    let port: u16 = env::var("PORT")
+        .expect("PORT should be defined")
+        .parse()
+        .expect("PORT should be an unsigned integer");
+
+    println!("connecting to {host}:{port} using TCP…");
+    let tcp_stream = TcpStream::connect((host.as_str(), port))
+        .await
+        .expect("should connect to TCP stream");
+
+    println!("preparing TCP connection for STARTTLS…");
+    let tcp_stream = RipStarttls::default()
+        .do_starttls_prefix(tcp_stream)
+        .await
+        .expect("should prepare TCP stream for IMAP STARTTLS");
+
+    println!("connection TLS-ready, disconnecting…");
+    tcp_stream
+        .shutdown(Shutdown::Both)
+        .expect("should close TCP stream");
+}

--- a/rip-starttls/src/imap/mod.rs
+++ b/rip-starttls/src/imap/mod.rs
@@ -5,6 +5,8 @@
 
 #[cfg(feature = "async-std")]
 pub mod async_std;
+#[cfg(feature = "smol")]
+pub mod smol;
 #[cfg(feature = "std")]
 pub mod std;
 #[cfg(feature = "tokio")]

--- a/rip-starttls/src/imap/smol.rs
+++ b/rip-starttls/src/imap/smol.rs
@@ -1,0 +1,53 @@
+//! # Async-std
+//!
+//! This module contains the async I/O connector based on
+//! [`async_std`] for [`RipStarttls`](super::RipStarttls).
+
+use std::io::Result;
+
+use async_net::TcpStream;
+use futures_lite::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use super::{Event, State};
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct RipStarttls {
+    state: super::RipStarttls,
+}
+
+impl RipStarttls {
+    pub fn new(handshake_discarded: bool) -> Self {
+        let state = super::RipStarttls::new(handshake_discarded);
+        Self { state }
+    }
+
+    pub async fn do_starttls_prefix(mut self, mut stream: TcpStream) -> Result<TcpStream> {
+        let mut event = None;
+
+        while let Some(output) = self.state.resume(event.take()) {
+            match output {
+                State::DiscardHandshake => {
+                    let mut line = String::new();
+                    let mut reader = BufReader::new(stream);
+                    reader.read_line(&mut line).await?;
+                    event = Some(Event::HandshakeDiscarded(line));
+                    stream = reader.into_inner();
+                }
+                State::WriteStarttlsCommand => {
+                    let cmd = super::RipStarttls::COMMAND;
+                    let count = stream.write(cmd.as_bytes()).await?;
+                    event = Some(Event::StarttlsCommandWrote(count));
+                }
+                State::DiscardResponse => {
+                    let mut line = String::new();
+                    let mut reader = BufReader::new(stream);
+                    reader.read_line(&mut line).await?;
+                    event = Some(Event::ResponseDiscarded(line));
+                    stream = reader.into_inner();
+                }
+            }
+        }
+
+        Ok(stream)
+    }
+}


### PR DESCRIPTION
Since async-std is deprecated this introduces a `smol` feature. We can deprecate async-std after that. I was first considering just migrating the `async-std` feature to `smol`, but async-std uses `async_std::net` and smol uses `async-net` and they are in fact different crates.