### PR TITLE
fix(email): fall back to client-side threading when IMAP server lacks UID THREAD

### DIFF
--- a/email/src/email/envelope/imap.rs
+++ b/email/src/email/envelope/imap.rs
@@ -70,6 +70,12 @@ impl Envelope {
                         msg.push(b'\n');
                     }
 
+                    if let Some(in_reply_to) = envelope.in_reply_to.0.as_ref() {
+                        msg.extend(b"In-Reply-To: ");
+                        msg.extend(in_reply_to.as_ref());
+                        msg.push(b'\n');
+                    }
+
                     if let Some(date) = envelope.date.0.as_ref() {
                         msg.extend(b"Date: ");
                         msg.extend(date.as_ref());

--- a/email/src/email/envelope/thread/maildir.rs
+++ b/email/src/email/envelope/thread/maildir.rs
@@ -1,13 +1,10 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
-use petgraph::{algo::astar, graphmap::DiGraphMap, Direction};
 use tracing::instrument;
 
-use super::ThreadEnvelopes;
+use super::{build_thread_graph_all, build_thread_graph_for_id, ThreadEnvelopes};
 use crate::{
     envelope::{
-        list::ListEnvelopesOptions, Envelopes, SingleId, ThreadedEnvelope, ThreadedEnvelopes,
+        list::ListEnvelopesOptions, Envelopes, SingleId, ThreadedEnvelopes,
     },
     maildir::MaildirContextSync,
     AnyResult, Error,
@@ -49,64 +46,7 @@ impl ThreadEnvelopes for ThreadMaildirEnvelopes {
             .map(|e| (e.id.clone(), e))
             .collect();
 
-        let envelopes = ThreadedEnvelopes::new(envelopes, move |envelopes| {
-            let msg_id_mapping: HashMap<_, _> = envelopes
-                .values()
-                .map(|e| (e.message_id.as_str(), e.id.as_str()))
-                .collect();
-
-            let mut graph = DiGraphMap::<&str, u8>::new();
-
-            for envelope in envelopes.values() {
-                match envelope.in_reply_to.as_ref() {
-                    Some(msg_id) => {
-                        if let Some(id) = msg_id_mapping.get(msg_id.as_str()) {
-                            graph.add_edge(*id, envelope.id.as_str(), 0);
-                        }
-                    }
-                    None => {
-                        graph.add_edge("0", envelope.id.as_str(), 0);
-                    }
-                };
-            }
-
-            let leafs: Vec<_> = graph
-                .nodes()
-                .filter(|node| graph.neighbors_directed(node, Direction::Outgoing).count() == 0)
-                .collect();
-
-            for leaf in leafs {
-                if let Some((_, path)) = astar(&graph, "0", |n| n == leaf, |_| 0, |_| 0) {
-                    let mut pairs = path.windows(2).enumerate();
-                    while let Some((depth, [a, b])) = pairs.next() {
-                        graph[(*a, *b)] = depth as u8;
-                    }
-                };
-            }
-
-            let mut final_graph = DiGraphMap::<ThreadedEnvelope, u8>::new();
-
-            for (a, b, w) in graph.all_edges() {
-                let eb = envelopes.get(&b.to_string()).unwrap();
-                match envelopes.get(&a.to_string()) {
-                    Some(ea) => {
-                        final_graph.add_edge(ea.as_threaded(), eb.as_threaded(), *w);
-                    }
-                    None => {
-                        let ea = ThreadedEnvelope {
-                            id: "0",
-                            message_id: "0",
-                            subject: "",
-                            from: "",
-                            date: Default::default(),
-                        };
-                        final_graph.add_edge(ea, eb.as_threaded(), *w);
-                    }
-                }
-            }
-
-            final_graph
-        });
+        let envelopes = ThreadedEnvelopes::new(envelopes, build_thread_graph_all);
 
         Ok(envelopes)
     }
@@ -127,68 +67,10 @@ impl ThreadEnvelopes for ThreadMaildirEnvelopes {
             .map(|e| (e.id.clone(), e))
             .collect();
 
-        let envelopes = ThreadedEnvelopes::new(envelopes, move |envelopes| {
-            let msg_id_mapping: HashMap<_, _> = envelopes
-                .values()
-                .map(|e| (e.message_id.as_str(), e.id.as_str()))
-                .collect();
-
-            let mut graph = DiGraphMap::<&str, u8>::new();
-
-            for envelope in envelopes.values() {
-                match envelope.in_reply_to.as_ref() {
-                    Some(msg_id) => {
-                        if let Some(id) = msg_id_mapping.get(msg_id.as_str()) {
-                            graph.add_edge(*id, envelope.id.as_str(), 0);
-                        }
-                    }
-                    None => {
-                        graph.add_edge("0", envelope.id.as_str(), 0);
-                    }
-                };
-            }
-
-            let leafs: Vec<_> = graph
-                .nodes()
-                .filter(|node| graph.neighbors_directed(node, Direction::Outgoing).count() == 0)
-                .collect();
-
-            let mut graph2 = DiGraphMap::<&str, u8>::new();
-
-            for leaf in leafs {
-                if let Some((_, path)) = astar(&graph, "0", |n| n == leaf, |_| 0, |_| 0) {
-                    if path.contains(&&id.as_str()) {
-                        let mut pairs = path.windows(2).enumerate();
-                        while let Some((depth, [a, b])) = pairs.next() {
-                            graph2.add_edge(*a, *b, depth as u8);
-                        }
-                    }
-                };
-            }
-
-            let mut final_graph = DiGraphMap::<ThreadedEnvelope, u8>::new();
-
-            for (a, b, w) in graph2.all_edges() {
-                let eb = envelopes.get(&b.to_string()).unwrap();
-                match envelopes.get(&a.to_string()) {
-                    Some(ea) => {
-                        final_graph.add_edge(ea.as_threaded(), eb.as_threaded(), *w);
-                    }
-                    None => {
-                        let ea = ThreadedEnvelope {
-                            id: "0",
-                            message_id: "0",
-                            subject: "",
-                            from: "",
-                            date: Default::default(),
-                        };
-                        final_graph.add_edge(ea, eb.as_threaded(), *w);
-                    }
-                }
-            }
-
-            final_graph
-        });
+        let envelopes =
+            ThreadedEnvelopes::new(envelopes, move |envelopes| {
+                build_thread_graph_for_id(envelopes, id.as_str())
+            });
 
         Ok(envelopes)
     }

--- a/email/src/email/envelope/thread/mod.rs
+++ b/email/src/email/envelope/thread/mod.rs
@@ -4,9 +4,14 @@ pub mod imap;
 #[cfg(feature = "maildir")]
 pub mod maildir;
 
-use async_trait::async_trait;
+use std::collections::HashMap;
 
-use super::{list::ListEnvelopesOptions, SingleId, ThreadedEnvelopes};
+use async_trait::async_trait;
+use petgraph::{algo::astar, graphmap::DiGraphMap, Direction};
+
+use super::{
+    list::ListEnvelopesOptions, Envelope, SingleId, ThreadedEnvelope, ThreadedEnvelopes,
+};
 use crate::AnyResult;
 
 #[async_trait]
@@ -27,4 +32,122 @@ pub trait ThreadEnvelopes: Send + Sync {
     ) -> AnyResult<ThreadedEnvelopes> {
         unimplemented!()
     }
+}
+
+/// Build a thread graph from envelopes using In-Reply-To / Message-ID
+/// relationships. This is a client-side threading algorithm that works
+/// regardless of whether the server supports IMAP THREAD.
+pub fn build_thread_graph_all(
+    envelopes: &HashMap<String, Envelope>,
+) -> DiGraphMap<ThreadedEnvelope<'_>, u8> {
+    let msg_id_mapping: HashMap<_, _> = envelopes
+        .values()
+        .map(|e| (e.message_id.as_str(), e.id.as_str()))
+        .collect();
+
+    let mut graph = DiGraphMap::<&str, u8>::new();
+
+    for envelope in envelopes.values() {
+        match envelope.in_reply_to.as_ref() {
+            Some(msg_id) => {
+                if let Some(id) = msg_id_mapping.get(msg_id.as_str()) {
+                    graph.add_edge(*id, envelope.id.as_str(), 0);
+                }
+            }
+            None => {
+                graph.add_edge("0", envelope.id.as_str(), 0);
+            }
+        };
+    }
+
+    let leafs: Vec<_> = graph
+        .nodes()
+        .filter(|node| graph.neighbors_directed(node, Direction::Outgoing).count() == 0)
+        .collect();
+
+    for leaf in leafs {
+        if let Some((_, path)) = astar(&graph, "0", |n| n == leaf, |_| 0, |_| 0) {
+            let mut pairs = path.windows(2).enumerate();
+            while let Some((depth, [a, b])) = pairs.next() {
+                graph[(*a, *b)] = depth as u8;
+            }
+        };
+    }
+
+    build_final_graph(envelopes, &graph)
+}
+
+/// Build a thread graph filtered to only the thread containing the
+/// given envelope ID.
+pub fn build_thread_graph_for_id<'a>(
+    envelopes: &'a HashMap<String, Envelope>,
+    id: &str,
+) -> DiGraphMap<ThreadedEnvelope<'a>, u8> {
+    let msg_id_mapping: HashMap<_, _> = envelopes
+        .values()
+        .map(|e| (e.message_id.as_str(), e.id.as_str()))
+        .collect();
+
+    let mut graph = DiGraphMap::<&str, u8>::new();
+
+    for envelope in envelopes.values() {
+        match envelope.in_reply_to.as_ref() {
+            Some(msg_id) => {
+                if let Some(parent_id) = msg_id_mapping.get(msg_id.as_str()) {
+                    graph.add_edge(*parent_id, envelope.id.as_str(), 0);
+                }
+            }
+            None => {
+                graph.add_edge("0", envelope.id.as_str(), 0);
+            }
+        };
+    }
+
+    let leafs: Vec<_> = graph
+        .nodes()
+        .filter(|node| graph.neighbors_directed(node, Direction::Outgoing).count() == 0)
+        .collect();
+
+    let mut filtered = DiGraphMap::<&str, u8>::new();
+
+    for leaf in leafs {
+        if let Some((_, path)) = astar(&graph, "0", |n| n == leaf, |_| 0, |_| 0) {
+            if path.contains(&id) {
+                let mut pairs = path.windows(2).enumerate();
+                while let Some((depth, [a, b])) = pairs.next() {
+                    filtered.add_edge(*a, *b, depth as u8);
+                }
+            }
+        };
+    }
+
+    build_final_graph(envelopes, &filtered)
+}
+
+fn build_final_graph<'a>(
+    envelopes: &'a HashMap<String, Envelope>,
+    graph: &DiGraphMap<&str, u8>,
+) -> DiGraphMap<ThreadedEnvelope<'a>, u8> {
+    let mut final_graph = DiGraphMap::<ThreadedEnvelope, u8>::new();
+
+    for (a, b, w) in graph.all_edges() {
+        let eb = envelopes.get(&b.to_string()).unwrap();
+        match envelopes.get(&a.to_string()) {
+            Some(ea) => {
+                final_graph.add_edge(ea.as_threaded(), eb.as_threaded(), *w);
+            }
+            None => {
+                let ea = ThreadedEnvelope {
+                    id: "0",
+                    message_id: "0",
+                    subject: "",
+                    from: "",
+                    date: Default::default(),
+                };
+                final_graph.add_edge(ea, eb.as_threaded(), *w);
+            }
+        }
+    }
+
+    final_graph
 }


### PR DESCRIPTION
Many IMAP servers (including Gmail) don't support the THREAD extension (RFC 5256). Previously this caused a hard error. This PR makes the IMAP backend try `UID THREAD` first and, on failure, fall back to client-side threading using `In-Reply-To`/`Message-ID` header relationships.

- Extract `In-Reply-To` from IMAP ENVELOPE responses (was previously ignored)
- Extract shared threading algorithm from maildir into `thread/mod.rs`
- Add client-side fallback in `thread/imap.rs` for both `thread_envelopes` and `thread_envelope`
- Simplify maildir backend to reuse the shared functions