### PR TITLE
feat: improve watch by fetching only new/changed messages instead of fetching everything (Mirador)

### DIFF
--- a/email/src/email/envelope/imap.rs
+++ b/email/src/email/envelope/imap.rs
@@ -30,6 +30,13 @@ pub static FETCH_ENVELOPES: Lazy<MacroOrMessageDataItemNames<'static>> = Lazy::n
     ])
 });
 
+pub static FETCH_FLAGS: Lazy<MacroOrMessageDataItemNames<'static>> = Lazy::new(|| {
+    MacroOrMessageDataItemNames::MessageDataItemNames(vec![
+        MessageDataItemName::Uid,
+        MessageDataItemName::Flags,
+    ])
+});
+
 impl Envelopes {
     pub fn from_imap_data_items(fetches: HashMap<NonZeroU32, Vec1<MessageDataItem>>) -> Self {
         fetches

--- a/email/src/email/envelope/watch/imap.rs
+++ b/email/src/email/envelope/watch/imap.rs
@@ -4,13 +4,22 @@ use async_trait::async_trait;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tracing::{debug, info};
 use utf7_imap::encode_utf7_imap as encode_utf7;
+use itertools::{Either, Itertools};
 
 use super::WatchEnvelopes;
-use crate::{envelope::Envelope, imap::ImapContext, AnyResult};
+use crate::{
+    envelope::{Envelope, Envelopes},
+    imap::ImapContext, AnyResult
+};
 
 #[derive(Clone, Debug)]
 pub struct WatchImapEnvelopes {
     ctx: ImapContext,
+}
+
+#[derive(Clone, Debug)]
+struct SyncState {
+    last_seen_uid: Option<u32>,
 }
 
 impl WatchImapEnvelopes {
@@ -46,11 +55,24 @@ impl WatchImapEnvelopes {
             .exists
             .unwrap() as usize;
 
+        let mut sync_state = SyncState {
+            last_seen_uid: None,
+        };
+
+        // Initial fetch of all envelopes
+        debug!("Starting initial fetch...");
+
         let envelopes = if envelopes_count == 0 {
             Default::default()
         } else {
             client.fetch_all_envelopes().await?
+            // Seems like we don't need to actually fetch envelopes for watch, just flags
+            // client.fetch_flags("1:*".try_into().unwrap()).await?
         };
+
+        // Track the highest UID we've seen
+        sync_state.last_seen_uid = self.get_max_uid(&envelopes);
+        debug!("Initial fetch: {} envelopes, last_seen_uid = {}", envelopes.len(), sync_state.last_seen_uid.unwrap());
 
         let mut envelopes: HashMap<String, Envelope> =
             HashMap::from_iter(envelopes.into_iter().map(|e| (e.id.clone(), e)));
@@ -60,15 +82,140 @@ impl WatchImapEnvelopes {
             client.idle(wait_for_shutdown_request).await?;
             info!("received IDLE change notification or timeout");
 
-            let next_envelopes = client.fetch_all_envelopes().await?;
-            let next_envelopes: HashMap<String, Envelope> =
-                HashMap::from_iter(next_envelopes.into_iter().map(|e| (e.id.clone(), e)));
+            let (new_envelopes, changed_envelopes, expunged_envelopes, last_seen_uid) = self.fetch_envelope_updates(
+                &mut client, &mut envelopes, sync_state.last_seen_uid).await?;
 
+            sync_state.last_seen_uid = last_seen_uid;
+
+            let mut next_envelopes: HashMap<String, Envelope> =
+                HashMap::from_iter(new_envelopes.iter().by_ref().map(|e| (e.id.clone(), e.clone())));
+            next_envelopes.extend(changed_envelopes.iter().by_ref().map(|e| (e.id.clone(), e.clone())));
+
+            // TODO: exec_hooks() should probably take in separate parameters for new/changed/expunged
             self.exec_hooks(config, &envelopes, &next_envelopes).await;
 
-            envelopes = next_envelopes;
+            for env in new_envelopes.into_iter() {
+                envelopes.insert(env.id.clone(), env);
+            }
+            for env in changed_envelopes.into_iter() {
+                debug!("Replacing flags for {}: old={:?}, updated={:?}",
+                    env.id.clone(),
+                    envelopes.get(&env.id.clone()).unwrap().flags,
+                    &env.flags);
+                envelopes.insert(env.id.clone(), env);
+            }
+            for env in expunged_envelopes.into_iter() {
+                envelopes.remove(&env.id);
+            }
         }
     }
+
+    fn get_max_uid(&self, envelopes: &[Envelope]) -> Option<u32> {
+        envelopes.iter().filter_map(|e| e.id.parse::<u32>().ok()).max()
+    }
+
+    /// Fetch new envelopes and changes to existing envelopes since the last seen UID
+    /// See RFC 4549, Section 3 and Section 4.3.1: https://www.rfc-editor.org/rfc/rfc4549
+    /// 1) Discover new messages using UID FETCH <lastseenuid+1>:* (ENVELOPE)
+    /// 2) Discover changes to existing messages using UID FETCH 1:<lastseenuid> (FLAGS)
+    // This will return (new_envelopes, changed_envelopes, expunged_envelopes, new_last_seen_uid)
+    async fn fetch_envelope_updates(
+        &self,
+        client: &mut crate::imap::ImapClient,
+        envelope_map: &HashMap<String, Envelope>,
+        last_seen_uid: Option<u32>,
+    ) -> AnyResult<(Envelopes, Envelopes, Envelopes, Option<u32>)> {
+        let (new_envelopes, _changed_envelopes_experimental) = self.fetch_new_envelopes(client, &envelope_map, last_seen_uid.unwrap()).await?;
+
+        let (changed_envelopes, expunged_envelopes) = self.fetch_existing_envelope_changes(
+            client, &envelope_map, last_seen_uid.unwrap()).await?;
+
+        let new_last_seen_uid = self.get_max_uid(&new_envelopes).max(last_seen_uid);
+
+        info!("Updated fetch: {} new envelopes, {} changed envelopes, {} expunged envelopes, new_last_seen_uid = {:?}",
+            new_envelopes.len(), changed_envelopes.len(), expunged_envelopes.len(), new_last_seen_uid);
+
+        debug!("New envelopes: {:?}", new_envelopes);
+        debug!("Changed envelopes (experimental): {:?}", _changed_envelopes_experimental);
+        debug!("Changed envelopes: {:?}", changed_envelopes);
+        debug!("Expunged envelopes: {:?}", expunged_envelopes);
+
+        Ok((new_envelopes, changed_envelopes, expunged_envelopes, new_last_seen_uid))
+    }
+
+    /// Fetch new envelopes since the last seen UID and return (new_envelopes, changed_envelopes)
+    async fn fetch_new_envelopes(
+        &self,
+        client: &mut crate::imap::ImapClient,
+        envelope_map: &HashMap<String, Envelope>,
+        last_seen_uid: u32,
+    ) -> AnyResult<(Envelopes, Envelopes)> {
+        debug!("Fetching new envelopes since UID {}", last_seen_uid);
+
+        // Discover new messages using UID FETCH <lastseenuid+1>:* (ENVELOPE)
+        let s = format!("{}:*", last_seen_uid + 1);
+        let fetched_envelopes = client
+            .fetch_envelopes_map(s.as_str().try_into().unwrap())
+            .await?;
+
+        // UID FETCH <lastseenuid+1>:* seems to always include lastseenuid, so we have to filter it out
+        // It seems some mail servers (e.g. Gmail) will actually return changed messages here as well (in addition to new messages).
+        // Perhaps this is an intersection of multiple features like a persistent IMAP connection + IDLE + CONDSTORE?
+        let (new_envelopes, changed_envelopes): (Vec<_>, Vec<_>) = fetched_envelopes.into_iter().map(|(_id, fetched)| fetched)
+            .filter_map(move |fetched| {
+                match envelope_map.get(&fetched.id) {
+                    None => Some(Either::Left(fetched)),
+                    Some(env) if fetched.flags != env.flags => {
+                        Some(Either::Right(fetched))
+                    },
+                    Some(_) => return None,
+                }
+            })
+            .partition_map(move |env| env);
+
+        Ok((Envelopes::from_iter(new_envelopes), Envelopes::from_iter(changed_envelopes)))
+    }
+
+    /// Fetch flags to existing envelopes up to last seen UID, and return (changed_envelopes, expunged_envelopes)
+    async fn fetch_existing_envelope_changes(
+        &self,
+        client: &mut crate::imap::ImapClient,
+        envelope_map: &HashMap<String, Envelope>,
+        last_seen_uid: u32,
+    ) -> AnyResult<(Envelopes, Envelopes)> {
+        debug!("Fetching changes to existing envelopes up to UID {}", last_seen_uid);
+
+        // Discover changes to existing messages using UID FETCH 1:<lastseenuid> (FLAGS)
+        let s = format!("1:{}", last_seen_uid);
+        let fetched_envelopes = client
+            .fetch_flags(s.as_str().try_into().unwrap())
+            .await?;
+
+        let fetched_envelope_map: HashMap<String, Envelope> =
+            HashMap::from_iter(fetched_envelopes.into_iter().map(|env| (env.id.clone(), env)));
+
+        let (changed_envelopes, expunged_envelopes): (Vec<_>, Vec<_>) = envelope_map
+            .values()
+            .filter_map(|env| {
+                match fetched_envelope_map.get(&env.id) {
+                    // Loop through previously fetched messages and compare with the updated fetch:
+                    // Envelopes that have their flags changed in the updated fetch are updated (e.g. marked as seen)
+                    // Envelopes that are not present in the updated fetch are expunged
+                    Some(fetched) if fetched.flags != env.flags => {
+                        // Clone existing env but replace with the updated fetched flags
+                        let mut changed_env = env.clone();
+                        changed_env.flags = fetched.flags.clone();
+                        Some(Either::Left(changed_env))
+                    },
+                    Some(_) => return None,
+                    None => Some(Either::Right(env.clone())),
+                }
+            })
+            .partition_map(move |env| env);
+
+        Ok((Envelopes::from_iter(changed_envelopes), Envelopes::from_iter(expunged_envelopes)))
+    }
+
 }
 
 #[async_trait]

--- a/email/src/email/envelope/watch/mod.rs
+++ b/email/src/email/envelope/watch/mod.rs
@@ -35,8 +35,10 @@ pub trait WatchEnvelopes: Send + Sync {
                 info!(id, "new message detected");
                 debug!("processing received envelope event…");
                 config.exec_received_envelope_hook(envelope).await;
-            } else {
-                // TODO
+            }
+            // an envelope has its flags changed
+            else {
+                info!(id, "changed message detected");
                 // debug!("processing any envelope event…");
                 // config.exec_any_envelope_hook(envelope).await;
             }


### PR DESCRIPTION
This PR improves Mirador's `watch` feature by avoiding fetching all messages on every idle loop, but instead only fetching new messages and changed/expunged messages.

@soywod I know you're pretty busy doing a major IO-free refactor of pimalaya/io-imap, so feel free to hold off on reviewing this until the refactor is done. (Just was excited to send this out since I was playing around with Mirador and finally got this working). I can rebase on the new code whenever it is released, looking forward 😁

(There's also some stuff I wasn't sure about, like if `exec_hooks()` should handle changed messages or not, but maybe we can discuss that later as well.)

This basically implements the basic sync algorithm from [RFC 4549 - Synchronization Operations for Disconnected IMAP4 Clients](https://www.rfc-editor.org/rfc/rfc4549#section-4.3), particularly particularly section 4.3.1. This doesn't make of the `CONDSTORE/CHANGEDSINCE/HIGHESTMODSEQ ` features directly (which would be the improved sync algorithm from section 6.1), but this should be an improvement beyond the existing Mirador watch feature which fetches all messages every loop:
1. Client discovers new messages from the server by doing `FETCH <lastseenuid+1>:*` (where <lastseenuid> is the latest UID of the latest message fetched from the last sync)
2. Client discovers changes and expunged messages using `UID FETCH 1:<lastseenuid> (FLAGS)`
   - Messages that were previously fetched but not in the updated fetch command are expunged

This should partially address some other issues related to Mirador watch functionality:
- pimalaya/io-imap#7 - improves watch functionality, but we're still using a polling mechanism. We would probably want to actually process `IDLE` events from the server and have fallback logic on the polling mechanism
- pimalaya/mirador#4 - this should at least improve `Control-C` behavior since we're not waiting on a full fetch every time

Note: Even though though this PR doesn't make use of `CONDSTORE` explicitly, it seems that some IMAP servers (e.g. Gmail) will return both new and updated messages after a `FETCH <lastseenuid+1>:*`. I didn't see this documented in the RFC, but maybe this is some IMAP behavior related to the intersection of a persistent IMAP connection + `IDLE` + `CONDSTORE`?

**email_lib::imap::ImapClient**:
- Add new methods `fetch_flags()` and `fetch_flags_map()`
- Change `fetch_all_envelopes()` to use `fetch_all_envelopes("1:*")` instead of `fetch_envelopes_by_sequence("1:*")` to use UIDs instead of sequence IDs