### PR TITLE
fix(email): treat orphaned replies as root nodes in client-side threading

### DIFF
--- a/email/src/email/envelope/thread/mod.rs
+++ b/email/src/email/envelope/thread/mod.rs
@@ -52,6 +52,10 @@ pub fn build_thread_graph_all(
             Some(msg_id) => {
                 if let Some(id) = msg_id_mapping.get(msg_id.as_str()) {
                     graph.add_edge(*id, envelope.id.as_str(), 0);
+                } else {
+                    // Parent not in this folder — treat as a root node
+                    // rather than silently dropping the envelope.
+                    graph.add_edge("0", envelope.id.as_str(), 0);
                 }
             }
             None => {
@@ -95,6 +99,9 @@ pub fn build_thread_graph_for_id<'a>(
             Some(msg_id) => {
                 if let Some(parent_id) = msg_id_mapping.get(msg_id.as_str()) {
                     graph.add_edge(*parent_id, envelope.id.as_str(), 0);
+                } else {
+                    // Parent not in this folder — treat as a root node
+                    graph.add_edge("0", envelope.id.as_str(), 0);
                 }
             }
             None => {


### PR DESCRIPTION
## Summary
- The client-side threading fallback silently drops emails whose `In-Reply-To` references a message not in the current folder (e.g. replies in Sent whose parent is in INBOX)
- Now these orphaned replies connect to the virtual root node, appearing as top-level threads

## RFC 5256 (REFERENCES algorithm)

Step 1A:

> If no message can be found with a given Message ID, create a dummy message with this ID. Use this dummy message for all subsequent references to this ID.

Step 2:

> Gather together all of the messages that have no parents and make them all children (siblings of one another) of a dummy parent (the "root").

The client-side fallback was skipping step 1A entirely — when a parent Message ID wasn't found in the local set, the child was silently dropped instead of being parented to root.

## Test plan
- `himalaya envelope list --folder sent` and `himalaya envelope thread --folder sent` now return the same count
- Replies in Sent correctly appear as top-level threads when their parent is in another folder