### PR TITLE
fix(smtp): prevent duplicate email delivery on connection errors

### DIFF
--- a/email/CHANGELOG.md
+++ b/email/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed SMTP retry loop causing duplicate email delivery on connection errors. [core#46]
+
 ## [0.26.4] - 2025-01-11
 
 ### Changed


### PR DESCRIPTION
## Summary

- Remove the SMTP send retry loop that reconnects and resends messages after IO/timeout errors
- When a connection error occurs mid-transaction (after the DATA payload is transmitted but before the 250 OK is received), the server has likely already accepted the message - retrying causes **duplicate emails**
- Replace with a single send attempt wrapped in a 30-second tokio::time::timeout
- Remove unused Retry import - use tokio::time::timeout and std::time::Duration directly

Closes #46

## Problem

The retry loop in SmtpContext::send() handles IO/timeout errors by reconnecting and resending the entire message. Since mail_send's send() performs the full SMTP transaction as one operation (EHLO, AUTH, MAIL FROM, RCPT TO, DATA, body), the caller cannot determine which phase failed. If the error occurred after the body was transmitted, the server already accepted the message - resending creates a duplicate.

The retry.reset() call after reconnection compounded the issue by resetting the attempt counter to 0, allowing infinite reconnect-and-resend cycles.

## Fix

Replace the retry loop with a single send attempt. This follows **at-most-once delivery** semantics - users can manually resend if delivery fails, but cannot un-send duplicates.

## Future enhancement

Phase-aware retry using the lower-level mail_from/rcpt_to/data methods would allow safe retry of the phases before message body transmission, if retry is desired.

## Related issues

- pimalaya/himalaya#619
- pimalaya/himalaya#629