### PR TITLE
fix(email): use page_cursor offset in paginate and apply_pagination

### DIFF
--- a/email/src/email/envelope/list/imap.rs
+++ b/email/src/email/envelope/list/imap.rs
@@ -303,7 +303,7 @@ fn paginate<T>(items: &[T], page: usize, page_size: usize) -> Result<&[T]> {
         Err(Error::BuildPageRangeOutOfBoundsImapError(page + 1))?
     }
 
-    Ok(&items[0..page_size.min(total)])
+    Ok(&items[page_cursor..(page_cursor + page_size).min(total)])
 }
 
 fn apply_pagination(
@@ -321,8 +321,8 @@ fn apply_pagination(
         return Ok(());
     }
 
-    let page_size = page_size.min(total);
-    *envelopes = Envelopes(envelopes[0..page_size].to_vec());
+    let end = (page_cursor + page_size).min(total);
+    *envelopes = Envelopes(envelopes[page_cursor..end].to_vec());
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Fix `paginate()` and `apply_pagination()` in the IMAP envelope listing backend to actually use the computed `page_cursor` offset when slicing results
- Both functions computed `page_cursor = page * page_size` but always sliced from index 0, causing every page to return page-1 data whenever a sort or filter query was present

## Reproduction

```bash
# Page 1 and page 2 return identical results (bug):
himalaya envelope list --folder INBOX --page-size 3 --page 1 order by date desc
himalaya envelope list --folder INBOX --page-size 3 --page 2 order by date desc

# Without the query, pagination works correctly:
himalaya envelope list --folder INBOX --page-size 3 --page 1
himalaya envelope list --folder INBOX --page-size 3 --page 2
```

## The fix

```diff
 fn paginate<T>(items: &[T], page: usize, page_size: usize) -> Result<&[T]> {
     ...
-    Ok(&items[0..page_size.min(total)])
+    Ok(&items[page_cursor..(page_cursor + page_size).min(total)])
 }

 fn apply_pagination(...) -> result::Result<(), Error> {
     ...
-    let page_size = page_size.min(total);
-    *envelopes = Envelopes(envelopes[0..page_size].to_vec());
+    let end = (page_cursor + page_size).min(total);
+    *envelopes = Envelopes(envelopes[page_cursor..end].to_vec());
 }
```

The no-query path (`build_sequence()`) already handles pagination correctly; only the query path was affected.