### PR TITLE
feat(email): include flags in thread envelope serialization

### DIFF
--- a/email/src/email/envelope/flag/mod.rs
+++ b/email/src/email/envelope/flag/mod.rs
@@ -41,6 +41,10 @@ use crate::email::error::Error;
 /// tries to be as simple as possible and should fit most of the use
 /// cases.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "derive",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub enum Flag {
     /// Flag used when the email envelope has been opened.
     Seen,
@@ -136,6 +140,10 @@ impl fmt::Display for Flag {
 /// The list of flags that can be attached to an email envelope. It
 /// uses a [`std::collections::HashSet`] to prevent duplicates.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "derive",
+    derive(serde::Serialize, serde::Deserialize)
+)]
 pub struct Flags(BTreeSet<Flag>);
 
 impl Hash for Flags {


### PR DESCRIPTION
## Summary

- Derive `Serialize`/`Deserialize` on `Flag` and `Flags` (behind the existing `derive` feature gate)
- Enrich `ThreadedEnvelopes` serialization to include `flags` and `has_attachment` on each threaded envelope by looking them up from the envelope map

Previously, `envelope thread` returned edges with only the base `ThreadedEnvelope` fields (id, message-id, subject, sender, date). Consumers that needed flag state (e.g. seen/unseen highlighting) had to make separate `envelope list` calls and merge flags client-side.

## Test plan

- [x] `cargo check -p email-lib --features thread,derive,imap` passes
- [x] `himalaya envelope thread` output includes `flags` and `has_attachment` on each envelope
- [x] Neovim thread listing shows seen/unseen highlighting on first render without additional enrichment calls